### PR TITLE
Minitest and avoid adding methods to the model

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+
+Rake::TestTask.new do |t|
+  t.libs.push "lib"
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
+end

--- a/attr_secure.gemspec
+++ b/attr_secure.gemspec
@@ -23,6 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.0.3"
 
   spec.add_dependency 'fernet'
-  spec.add_dependency 'activesupport', ' ~> 3.2.0'
   spec.add_dependency 'activerecord',  ' ~> 3.2.0'
 end

--- a/attr_secure.gemspec
+++ b/attr_secure.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "minitest", "~> 5.0.3"
 
   spec.add_dependency 'fernet'
   spec.add_dependency 'activesupport', ' ~> 3.2.0'
+  spec.add_dependency 'activerecord',  ' ~> 3.2.0'
 end

--- a/lib/attr_secure.rb
+++ b/lib/attr_secure.rb
@@ -1,5 +1,6 @@
 require "attr_secure/version"
 require 'fernet'
+require 'active_record'
 
 Fernet::Configuration.run do |config|
   config.enforce_ttl = false

--- a/lib/attr_secure.rb
+++ b/lib/attr_secure.rb
@@ -2,42 +2,23 @@ require "attr_secure/version"
 require 'fernet'
 require 'active_record'
 
+require 'attr_secure/secure'
+
 Fernet::Configuration.run do |config|
   config.enforce_ttl = false
 end
 
 module AttrSecure
-  extend ActiveSupport::Concern
 
-  def env!(key)
-    ENV[key] || raise("Missing ENV(#{key})")
-  end
-
-  def encrypt(value)
-    Fernet.generate(env!('ATTR_SECURE_SECRET')) do |generator|
-      generator.data = { value: value }
-    end
-  end
-
-  def decrypt(value)
-    return nil if value.nil?
-    verifier = Fernet.verifier(env!('ATTR_SECURE_SECRET'), value)
-    verifier.data["value"] if verifier.valid?
-  end
-
-  module ClassMethods
-
-    def attr_secure(attribute)
-      define_method("#{attribute}=") do |value|
-        write_attribute(attribute, encrypt(value.nil? ? nil : value.to_sym))
-      end
-
-      define_method("#{attribute}") do
-        decrypt read_attribute(attribute.to_sym)
-      end
+  def attr_secure(attribute)
+    define_method("#{attribute}=") do |value|
+      write_attribute(attribute, Secure.new.encrypt(value.nil? ? nil : value.to_sym))
     end
 
+    define_method("#{attribute}") do
+      Secure.new.decrypt read_attribute(attribute.to_sym)
+    end
   end
 end
 
-ActiveRecord::Base.send(:include, AttrSecure)
+ActiveRecord::Base.send(:extend, AttrSecure)

--- a/lib/attr_secure/secure.rb
+++ b/lib/attr_secure/secure.rb
@@ -1,0 +1,25 @@
+module AttrSecure
+  class Secure
+
+    def encrypt(value)
+      Fernet.generate(attr_secure_secret) do |generator|
+        generator.data = { value: value }
+      end
+    end
+
+    def decrypt(value)
+      return nil if value.nil?
+      verifier = Fernet.verifier(attr_secure_secret, value)
+      verifier.data["value"] if verifier.valid?
+    end
+
+    private
+    def env!(key)
+      ENV.fetch(key) { raise("Missing ENV(#{key})") }
+    end
+
+    def attr_secure_secret
+      env!('ATTR_SECURE_SECRET')
+    end
+  end
+end

--- a/test/attr_secure_test.rb
+++ b/test/attr_secure_test.rb
@@ -3,7 +3,7 @@ require 'minitest/mock'
 require 'attr_secure'
 
 class FakeModelWithSecureAttributes
-  include AttrSecure
+  extend AttrSecure
   attr_accessor :attributes
 
   attr_secure :foo

--- a/test/attr_secure_test.rb
+++ b/test/attr_secure_test.rb
@@ -1,0 +1,56 @@
+require 'minitest/autorun'
+require 'minitest/mock'
+require 'attr_secure'
+
+class FakeModelWithSecureAttributes
+  include AttrSecure
+  attr_accessor :attributes
+
+  attr_secure :foo
+
+  def initialize(attributes={})
+    @attributes = attributes
+  end
+
+  def read_attribute(attr_name)
+    attributes[attr_name]
+  end
+
+  def write_attribute(attr_name, value)
+    attributes[attr_name] = value
+  end
+end
+
+class TestAttrSecure < MiniTest::Unit::TestCase
+  def setup
+    @subject = FakeModelWithSecureAttributes.new
+    ENV['ATTR_SECURE_SECRET'] = 'xxx'
+  end
+
+  def test_encrypt
+    encrypter = lambda { |secret|
+      assert_equal 'xxx', secret
+      'world'
+    }
+
+    Fernet.stub :generate, encrypter do |f|
+      @subject.foo = 'hello'
+      assert_equal 'world', @subject.attributes[:foo]
+    end
+  end
+
+  def test_decrypt
+    decrypter_mock = MiniTest::Mock.new
+    decrypter_mock.expect(:valid?, true)
+    decrypter_mock.expect(:data, {'value' => 'world'})
+
+    Fernet.stub(:generate, 'world') do
+      Fernet.stub(:verifier, decrypter_mock) do
+        @subject.foo = 'hello'
+        assert_equal 'world', @subject.foo
+      end
+    end
+
+    decrypter_mock.verify
+  end
+end


### PR DESCRIPTION
This does two things : 
- Add MiniTest and tests to check encryption and decryption work as expected.
- Refactor the module to avoid adding methods to the model.

Previously, the encrypt and decrypt methods were added to all ActiveRecord models.
As these names are quite common, they might conflict with other method names in the models.
This uses an other class so the only method added to the models is attr_secure.

I also removed the dependency to ActiveSupport since it was a trivial change and avoids loading an other framework.
