### PR TITLE
Support both major versions of fernet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .bundle
 .config
 .yardoc
-Gemfile.lock
+*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ rvm:
   - 2.0.0
   - jruby-19mode
 
+gemfile:
+  - Gemfile
+  - gemfiles/Gemfile.fernet_1.6
+
 matrix:
   allow_failures:
     - rvm: jruby-19mode

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ similar.  Encrypted values are long.
 
 You can pass a comma delimited list of keys (or an array of keys) as your secret.  attr_secure will decrypt with each key in turn until it hits a verified value.  Encryption always happens with the newest (leftmost) key.
 
+## Fernet version
+
+Attr Secure supports both Fernet 1.6 and 2.0. By default, the latest version will be used.  
+If you wish to use the 1.6 releases, you need to specify so in your own Gemfile with the following:
+
+    gem 'attr_secure'
+    gem 'fernet', '~> 1.6'
+
 ## Contributing
 
 1. Fork it

--- a/attr_secure.gemspec
+++ b/attr_secure.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", '~> 2.14.1'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activerecord"
   spec.add_development_dependency "sequel"

--- a/attr_secure.gemspec
+++ b/attr_secure.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel"
   spec.add_development_dependency "sqlite3"
 
-  spec.add_dependency 'fernet', '<= 2.0rc2'
+  spec.add_dependency 'fernet', '< 3.0'
 end

--- a/attr_secure.gemspec
+++ b/attr_secure.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sequel"
   spec.add_development_dependency "sqlite3"
 
-  spec.add_dependency 'fernet', '1.6'
+  spec.add_dependency 'fernet', '<= 2.0rc2'
 end

--- a/gemfiles/Gemfile.fernet_1.6
+++ b/gemfiles/Gemfile.fernet_1.6
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in attr_secure.gemspec
+gemspec :path => '..'
+
+gem 'fernet', '1.6'

--- a/lib/attr_secure/fernet/1.rb
+++ b/lib/attr_secure/fernet/1.rb
@@ -1,0 +1,26 @@
+Fernet::Configuration.run do |config|
+  config.enforce_ttl = false
+end
+
+module AttrSecure
+  module Fernet
+
+    def encrypt(value)
+      ::Fernet.generate([secret].flatten.first) do |generator|
+        generator.data = { value: value }
+      end
+    end
+
+    def decrypt(value)
+      return nil if value.nil?
+      [secret].flatten.each do |_secret|
+        begin
+          verifier = ::Fernet.verifier(_secret, value)
+          return verifier.data['value'] if verifier.valid?
+        rescue
+        end
+      end
+      raise OpenSSL::Cipher::CipherError
+    end
+  end
+end

--- a/lib/attr_secure/fernet/2.rb
+++ b/lib/attr_secure/fernet/2.rb
@@ -1,0 +1,25 @@
+Fernet::Configuration.run do |config|
+  config.enforce_ttl = false
+end
+
+module AttrSecure
+  module Fernet
+
+    def encrypt(value)
+      ::Fernet.generate([secret].flatten.first, value)
+    end
+
+    def decrypt(value)
+      return nil if value.nil?
+
+      [secret].flatten.each do |_secret|
+        begin
+          verifier = ::Fernet.verifier(_secret, value)
+          return verifier.message if verifier.valid?
+        rescue
+        end
+      end
+      raise OpenSSL::Cipher::CipherError
+    end
+  end
+end

--- a/lib/attr_secure/secure.rb
+++ b/lib/attr_secure/secure.rb
@@ -1,7 +1,7 @@
 require 'fernet'
 
 case Fernet::VERSION
-  when /^2\.0/
+  when /^2/
     require 'attr_secure/fernet/2'
   when /^1\.6/
     require 'attr_secure/fernet/1'


### PR DESCRIPTION
This aims to support both major versions of fernet.
- To use 1.6, the app will have to specify that version in it's Gemfile, or the latest version will be used by default.
- To use 2.0, just specify attr_secure.
